### PR TITLE
Fixed resources link

### DIFF
--- a/articles/tidbits/82-html-audio-tag.md
+++ b/articles/tidbits/82-html-audio-tag.md
@@ -197,4 +197,3 @@ _[@MrBenJ5](https://twitter.com/samantha_ming/status/1236933988293308416?s=21):_
 - [HTML | audio preload Attribute](https://www.geeksforgeeks.org/html-audio-preload-attribute/)
 - [Smashing Magazine: Preload: What Is It Good For?](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/)
 - [HTML standard](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-media-preload)
-- [w3schools: HTML Audio - Browser Support](https://www.w3schools.com/html/html5_audio.asp)

--- a/articles/tidbits/82-html-audio-tag.md
+++ b/articles/tidbits/82-html-audio-tag.md
@@ -187,7 +187,7 @@ _[@MrBenJ5](https://twitter.com/samantha_ming/status/1236933988293308416?s=21):_
 
 ## Resources
 
-- [MDN Web Docs: HTML audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audioHTML)
+- [MDN Web Docs: HTML audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
 - [w3schools: HTML audio](https://www.w3schools.com/html/html5_audio.asp)
 - [w3docs: HTML audio](https://www.w3docs.com/learn-html/html-audio-tag.html)
 - [TutorialRepublic: HTML audio](https://www.tutorialrepublic.com/html-reference/html5-audio-tag.php)


### PR DESCRIPTION
In Tidbits article 82, there is 2 change.
1. Resources link MDN is not found. It is point to the wrong URL.
2. There are duplicate link for W3School.