### PR TITLE
Change splice to split in split() post

### DIFF
--- a/articles/basics/string-split.md
+++ b/articles/basics/string-split.md
@@ -2,7 +2,7 @@
 
 As many of you know, I’ve been sharing weekly code tidbits. In this new series, I want to focus on topics that are programming essentials - things that you absolutely should know as a developer! For the more advance programmers, you can view these posts as a reminder of what you already know. For the code newbies, this will be a nice gateway into the wonderful world of programming 💻
 
-In today’s lesson, let’s learn about `split()`! This method slices up your string into separate substrings. In my example, I’m splitting it by `splice('')` which means split each letter. So the output is an array of each letter.
+In today’s lesson, let’s learn about `split()`! This method slices up your string into separate substrings. In my example, I’m splitting it by `split('')` which means split each letter. So the output is an array of each letter.
 
 ```javascript
 const name = 'samantha';


### PR DESCRIPTION
I was looking for resources to send a friend (I love your stuff!) and I noticed that the String.split entry under Web Basics mentions "`splice('')`" when it seems to be referring to calling `split` and passing in empty quotes. I assume it's a typo since I didn't see any other mention of `splice` (or array methods) in that article.