### PR TITLE
fix: typo in example comment

### DIFF
--- a/articles/tidbits/92-6-use-cases-of-spread-with-array.md
+++ b/articles/tidbits/92-6-use-cases-of-spread-with-array.md
@@ -9,7 +9,7 @@ Here are 6 ways to use the Spread operator with Array in JavaScript. You can use
 // Clone Array
 [...array]
 
-// Sting → Array
+// String → Array
 [...'string']
 
 // Set  → Array


### PR DESCRIPTION
Correcting a typo in a comment for one of the examples