### PR TITLE
Fix incorrect property in Inverse example

### DIFF
--- a/articles/tidbits/88-css-placeholder-shown.md
+++ b/articles/tidbits/88-css-placeholder-shown.md
@@ -169,7 +169,7 @@ We can do the inverse of something using the `:not` pseudo-class. Here, we can t
 ```
 
 ```css
-input:not(:placeholder) {
+input:not(:placeholder-shown) {
   border-color: green;
 }
 ```


### PR DESCRIPTION
Inverse :placeholder-shown with :not css used `:placeholder` instead of `:placeholder-shown`.

Great article!